### PR TITLE
Reduce repetitive 'comma' implementations

### DIFF
--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use tokenizer::{PeekableTokens, Token};
+use types::FromTokens;
 
 
 pub struct Coord {
@@ -22,8 +23,8 @@ pub struct Coord {
     pub m: Option<f64>,
 }
 
-impl Coord {
-    pub fn from_tokens(tokens: &mut PeekableTokens) ->  Result<Self, &'static str> {
+impl FromTokens for Coord {
+    fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
         let x = match tokens.next() {
             Some(Token::Number(n)) => n,
             _ => return Err("Expected a number for the X coordinate"),

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -30,22 +30,7 @@ impl LineString {
 
 impl FromTokens for LineString {
     fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
-        let mut coords = Vec::new();
-
-        coords.push(match Coord::from_tokens(tokens) {
-            Ok(c) => c,
-            Err(s) => return Err(s),
-        });
-
-        while let Some(&Token::Comma) = tokens.peek() {
-            tokens.next();  // throw away comma
-
-            coords.push(match Coord::from_tokens(tokens) {
-                Ok(c) => c,
-                Err(s) => return Err(s),
-            });
-        }
-
-        Ok(LineString {coords: coords})
+        let result: Result<Vec<Coord>, _> = FromTokens::comma_many(FromTokens::from_tokens, tokens);
+        result.map(|vec| LineString {coords: vec})
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,4 +36,25 @@ pub trait FromTokens: Sized {
         };
         result
     }
+
+    fn comma_many<F>(f: F, tokens: &mut PeekableTokens) -> Result<Vec<Self>, &'static str>
+            where F: Fn(&mut PeekableTokens) -> Result<Self, &'static str> {
+        let mut items = Vec::new();
+
+        match f(tokens) {
+            Ok(i) => items.push(i),
+            Err(s) => return Err(s),
+        };
+
+        while let Some(&Token::Comma) = tokens.peek() {
+            tokens.next();  // throw away comma
+
+            match f(tokens) {
+                Ok(i) => items.push(i),
+                Err(s) => return Err(s),
+            };
+        }
+
+        Ok(items)
+    }
 }

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -30,26 +30,7 @@ impl MultiPoint {
 
 impl FromTokens for MultiPoint {
     fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
-        let mut points = Vec::new();
-
-        let x: Result<Point, _> = FromTokens::from_tokens_with_parens(tokens);
-
-        points.push(match x {
-            Ok(p) => p,
-            Err(s) => return Err(s),
-        });
-
-        while let Some(&Token::Comma) = tokens.peek() {
-            tokens.next();  // throw away comma
-
-            let x: Result<Point, _> = FromTokens::from_tokens_with_parens(tokens);
-
-            points.push(match x {
-                Ok(p) => p,
-                Err(s) => return Err(s),
-            });
-        }
-
-        Ok(MultiPoint {points: points})
+        let result: Result<Vec<Point>, _> = FromTokens::comma_many(FromTokens::from_tokens_with_parens, tokens);
+        result.map(|vec| MultiPoint {points: vec})
     }
 }

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -30,10 +30,7 @@ impl Point {
 
 impl FromTokens for Point {
     fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
-        let coord = match Coord::from_tokens(tokens) {
-            Ok(c) => c,
-            Err(s) => return Err(s),
-        };
-        Ok(Point {coord: coord})
+        let result: Result<Coord, _> = FromTokens::from_tokens(tokens);
+        result.map(|coord| Point {coord: coord})
     }
 }

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -30,26 +30,7 @@ impl Polygon {
 
 impl FromTokens for Polygon {
     fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
-        let mut lines = Vec::new();
-
-        let x: Result<LineString, _> = FromTokens::from_tokens_with_parens(tokens);
-
-        lines.push(match x {
-            Ok(l) => l,
-            Err(s) => return Err(s),
-        });
-
-        while let Some(&Token::Comma) = tokens.peek() {
-            tokens.next();  // throw away comma
-
-            let x: Result<LineString, _> = FromTokens::from_tokens_with_parens(tokens);
-
-            lines.push(match x {
-                Ok(c) => c,
-                Err(s) => return Err(s),
-            });
-        }
-
-        Ok(Polygon { lines: lines })
+        let result: Result<Vec<LineString>, _> = FromTokens::comma_many(FromTokens::from_tokens_with_parens, tokens);
+        result.map(|vec| Polygon {lines: vec})
     }
 }


### PR DESCRIPTION
So I went a little nuts here, but it makes some of the from_tokens
implementations really concise and sexy.