### PR TITLE
Relicense as "MIT/Apache-2.0".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "wkt"
 description = "Rust read/write support for well-known text (WKT)"
 version = "0.0.6"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
-license = "Apache-2.0"
+license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/rust-wkt"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -3,4 +3,17 @@ rust-wkt
 
 [![Build Status](https://travis-ci.org/georust/rust-wkt.svg?branch=master)](https://travis-ci.org/georust/rust-wkt)
 
-Licensed under version two of the Apache License.
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.


### PR DESCRIPTION
I'm the only contributor, so this should be a straightforward license
change.