### PR TITLE
Implement Display for geometries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 
 use std::ascii::AsciiExt;
 use std::default::Default;
+use std::fmt;
 
 use tokenizer::{PeekableTokens, Token, Tokens};
 use types::GeometryCollection;
@@ -79,6 +80,21 @@ impl Geometry {
         }
     }
 }
+
+impl fmt::Display for Geometry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Geometry::Point(point) => point.fmt(f),
+            Geometry::LineString(linestring) => linestring.fmt(f),
+            Geometry::Polygon(polygon) => polygon.fmt(f),
+            Geometry::MultiPoint(multipoint) => multipoint.fmt(f),
+            Geometry::MultiLineString(multilinstring) => multilinstring.fmt(f),
+            Geometry::MultiPolygon(multipolygon) => multipolygon.fmt(f),
+            Geometry::GeometryCollection(geometrycollection) => geometrycollection.fmt(f),
+        }
+    }
+}
+
 pub struct Wkt {
     pub items: Vec<Geometry>,
 }

--- a/src/types/coord.rs
+++ b/src/types/coord.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use tokenizer::{PeekableTokens, Token};
 use FromTokens;
 
@@ -21,6 +22,19 @@ pub struct Coord {
     pub y: f64,
     pub z: Option<f64>,
     pub m: Option<f64>,
+}
+
+impl fmt::Display for Coord {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{} {}", self.x, self.y)?;
+        if let Some(z) = self.z {
+            write!(f, " {}", z)?;
+        }
+        if let Some(m) = self.m {
+            write!(f, " {}", m)?;
+        }
+        Ok(())
+    }
 }
 
 impl FromTokens for Coord {
@@ -39,5 +53,58 @@ impl FromTokens for Coord {
             z: None,
             m: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Coord;
+
+    #[test]
+    fn write_2d_coord() {
+        let coord = Coord {
+            x: 10.1,
+            y: 20.2,
+            z: None,
+            m: None,
+        };
+
+        assert_eq!("10.1 20.2", format!("{}", coord));
+    }
+
+    #[test]
+    fn write_3d_coord() {
+        let coord = Coord {
+            x: 10.1,
+            y: 20.2,
+            z: Some(-30.3),
+            m: None,
+        };
+
+        assert_eq!("10.1 20.2 -30.3", format!("{}", coord));
+    }
+
+    #[test]
+    fn write_2d_coord_with_linear_referencing_system() {
+        let coord = Coord {
+            x: 10.1,
+            y: 20.2,
+            z: None,
+            m: Some(10.),
+        };
+
+        assert_eq!("10.1 20.2 10", format!("{}", coord));
+    }
+
+    #[test]
+    fn write_3d_coord_with_linear_referencing_system() {
+        let coord = Coord {
+            x: 10.1,
+            y: 20.2,
+            z: Some(-30.3),
+            m: Some(10.),
+        };
+
+        assert_eq!("10.1 20.2 -30.3 10", format!("{}", coord));
     }
 }

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use tokenizer::PeekableTokens;
 use types::linestring::LineString;
 use FromTokens;
@@ -26,17 +27,41 @@ impl MultiLineString {
     }
 }
 
+impl fmt::Display for MultiLineString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        if self.0.is_empty() {
+            f.write_str("MULTILINESTRING EMPTY")
+        } else {
+            let strings = self
+                .0
+                .iter()
+                .map(|l| {
+                    l.0
+                        .iter()
+                        .map(|c| format!("{} {}", c.x, c.y))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                })
+                .collect::<Vec<_>>()
+                .join("),(");
+
+            write!(f, "MULTILINESTRING(({}))", strings)
+        }
+    }
+}
+
 impl FromTokens for MultiLineString {
     fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
         let result =
             FromTokens::comma_many(<LineString as FromTokens>::from_tokens_with_parens, tokens);
-        result.map(|vec| MultiLineString(vec))
+        result.map(MultiLineString)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::MultiLineString;
+    use super::{LineString, MultiLineString};
+    use types::Coord;
     use {Geometry, Wkt};
 
     #[test]
@@ -50,5 +75,51 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(2, lines.len());
+    }
+
+    #[test]
+    fn write_empty_multilinestring() {
+        let multilinestring = MultiLineString(vec![]);
+
+        assert_eq!("MULTILINESTRING EMPTY", format!("{}", multilinestring));
+    }
+
+    #[test]
+    fn write_multilinestring() {
+        let multilinestring = MultiLineString(vec![
+            LineString(vec![
+                Coord {
+                    x: 10.1,
+                    y: 20.2,
+                    z: None,
+                    m: None,
+                },
+                Coord {
+                    x: 30.3,
+                    y: 40.4,
+                    z: None,
+                    m: None,
+                },
+            ]),
+            LineString(vec![
+                Coord {
+                    x: 50.5,
+                    y: 60.6,
+                    z: None,
+                    m: None,
+                },
+                Coord {
+                    x: 70.7,
+                    y: 80.8,
+                    z: None,
+                    m: None,
+                },
+            ]),
+        ]);
+
+        assert_eq!(
+            "MULTILINESTRING((10.1 20.2,30.3 40.4),(50.5 60.6,70.7 80.8))",
+            format!("{}", multilinestring)
+        );
     }
 }

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use tokenizer::PeekableTokens;
 use types::polygon::Polygon;
 use FromTokens;
@@ -26,17 +27,47 @@ impl MultiPolygon {
     }
 }
 
+impl fmt::Display for MultiPolygon {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        if self.0.is_empty() {
+            f.write_str("MULTIPOLYGON EMPTY")
+        } else {
+            let strings = self
+                .0
+                .iter()
+                .map(|p| {
+                    p.0
+                        .iter()
+                        .map(|l| {
+                            l.0
+                                .iter()
+                                .map(|c| format!("{} {}", c.x, c.y))
+                                .collect::<Vec<String>>()
+                                .join(",")
+                        })
+                        .collect::<Vec<String>>()
+                        .join("),(")
+                })
+                .collect::<Vec<String>>()
+                .join(")),((");
+
+            write!(f, "MULTIPOLYGON((({})))", strings)
+        }
+    }
+}
+
 impl FromTokens for MultiPolygon {
     fn from_tokens(tokens: &mut PeekableTokens) -> Result<Self, &'static str> {
         let result =
             FromTokens::comma_many(<Polygon as FromTokens>::from_tokens_with_parens, tokens);
-        result.map(|vec| MultiPolygon(vec))
+        result.map(MultiPolygon)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::MultiPolygon;
+    use super::{MultiPolygon, Polygon};
+    use types::{Coord, LineString};
     use {Geometry, Wkt};
 
     #[test]
@@ -50,5 +81,103 @@ mod tests {
             _ => unreachable!(),
         };
         assert_eq!(2, polygons.len());
+    }
+
+    #[test]
+    fn write_empty_multipolygon() {
+        let multipolygon = MultiPolygon(vec![]);
+
+        assert_eq!("MULTIPOLYGON EMPTY", format!("{}", multipolygon));
+    }
+
+    #[test]
+    fn write_multipolygon() {
+        let multipolygon = MultiPolygon(vec![
+            Polygon(vec![
+                LineString(vec![
+                    Coord {
+                        x: 0.,
+                        y: 0.,
+                        z: None,
+                        m: None,
+                    },
+                    Coord {
+                        x: 20.,
+                        y: 40.,
+                        z: None,
+                        m: None,
+                    },
+                    Coord {
+                        x: 40.,
+                        y: 0.,
+                        z: None,
+                        m: None,
+                    },
+                    Coord {
+                        x: 0.,
+                        y: 0.,
+                        z: None,
+                        m: None,
+                    },
+                ]),
+                LineString(vec![
+                    Coord {
+                        x: 5.,
+                        y: 5.,
+                        z: None,
+                        m: None,
+                    },
+                    Coord {
+                        x: 20.,
+                        y: 30.,
+                        z: None,
+                        m: None,
+                    },
+                    Coord {
+                        x: 30.,
+                        y: 5.,
+                        z: None,
+                        m: None,
+                    },
+                    Coord {
+                        x: 5.,
+                        y: 5.,
+                        z: None,
+                        m: None,
+                    },
+                ]),
+            ]),
+            Polygon(vec![LineString(vec![
+                Coord {
+                    x: 40.,
+                    y: 40.,
+                    z: None,
+                    m: None,
+                },
+                Coord {
+                    x: 20.,
+                    y: 45.,
+                    z: None,
+                    m: None,
+                },
+                Coord {
+                    x: 45.,
+                    y: 30.,
+                    z: None,
+                    m: None,
+                },
+                Coord {
+                    x: 40.,
+                    y: 40.,
+                    z: None,
+                    m: None,
+                },
+            ])]),
+        ]);
+
+        assert_eq!(
+            "MULTIPOLYGON(((0 0,20 40,40 0,0 0),(5 5,20 30,30 5,5 5)),((40 40,20 45,45 30,40 40)))",
+            format!("{}", multipolygon)
+        );
     }
 }


### PR DESCRIPTION
fix https://github.com/georust/rust-wkt/issues/31

write some wkt
- POINT EMPTY
- POINT(..)
- POINT Z(..)
- POINT ZM(..)
- LINESTRING EMPTY
- LINESTRING(...)
- POLYGON EMPTY
- POLYGON (...)
- MULTIPOINT EMPTY
- MULTIPOINT (...)
- MULTILINESTRING EMPTY
- MULTILINESTRING (...)
- MULTIPOLYGON EMPTY
- MULTIPOLYGON (...)
- GEOMETRYCOLLECTION EMPTY
- GEOMETRYCOLLECTION (...)

I have not handled every case like `MULTILINESTRING ZM` but we can make an issue for that.
I don't know the exhaustive list of cases